### PR TITLE
Remove \n in injection css styles...

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -482,7 +482,7 @@ void MainWindow::UpdatePage(const QString &filename_url)
     if (ss.useWSPreWrap()) {
         int endheadpos = text.indexOf("</head>");
         if (endheadpos > 1) {
-	    QString inject_editstyle = "<style type=\"text/css\">" + EDIT_WITH_PRE_WRAP + "</style>\n"; 
+	    QString inject_editstyle = "<style type=\"text/css\">" + EDIT_WITH_PRE_WRAP + "</style>"; 
 	    text.insert(endheadpos, inject_editstyle);
         }
     }
@@ -493,7 +493,7 @@ void MainWindow::UpdatePage(const QString &filename_url)
         if (endheadpos > 1) {
             QString inject_userstyles = 
               "<link rel=\"stylesheet\" type=\"text/css\" "
-	      "href=\"" + m_usercssurl + "\" />\n";
+	      "href=\"" + m_usercssurl + "\" />";
 	    // qDebug() << "WebView injecting stylesheet: " << inject_userstyles;
             text.insert(endheadpos, inject_userstyles);
         }


### PR DESCRIPTION
because unnecessary empty lines are created before "</ head>" after Save (once).

The issue appears when:
a) we use our own css file (custom_webview_style.css)
b) we have enabled in the preferences (css-white-space: pre-wrap)

For two injections – two empty lines after Save.