### PR TITLE
Larger icon for the edit mode

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -1846,7 +1846,8 @@ void MainWindow::ExtendIconSizes()
 
     icon = ui.actionMode->icon();
     icon.addFile(QString::fromUtf8(":/icons/mode-preview_22px.png"), QSize(22,22), QIcon::Normal, QIcon::Off);
-    icon.addFile(QString::fromUtf8(":/icons/mode-edit_48px.png"), QSize(22,22), QIcon::Normal, QIcon::On);
+    icon.addFile(QString::fromUtf8(":/icons/mode-edit_22px.png"), QSize(22,22), QIcon::Normal, QIcon::On);
+    icon.addFile(QString::fromUtf8(":/icons/mode-edit_48px.png"), QSize(48,48), QIcon::Normal, QIcon::On);
     ui.actionMode->setIcon(icon);
 
     icon = ui.actionNext->icon();

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -1846,7 +1846,7 @@ void MainWindow::ExtendIconSizes()
 
     icon = ui.actionMode->icon();
     icon.addFile(QString::fromUtf8(":/icons/mode-preview_22px.png"), QSize(22,22), QIcon::Normal, QIcon::Off);
-    icon.addFile(QString::fromUtf8(":/icons/mode-edit_22px.png"), QSize(22,22), QIcon::Normal, QIcon::On);
+    icon.addFile(QString::fromUtf8(":/icons/mode-edit_48px.png"), QSize(22,22), QIcon::Normal, QIcon::On);
     ui.actionMode->setIcon(icon);
 
     icon = ui.actionNext->icon();


### PR DESCRIPTION
I know this change does not make sense, but I checked it a few weeks ago and forgot to prepare Pull Request.

How to check?
1. Go to edit mode (pencil icon)
2. Set the maximum icons in Preferences> Appearance> Main UI
3. Note that this one and only icon has not grown.

That is why in this unique place we have to load the "big" pencil right away.

It is possible that there is another solution, but I admit that I did not find it. It just works.