### PR TITLE
translate pageedit_en.ts into Simplified Chinese

### DIFF
--- a/ts/pageedit_zh_CN.ts
+++ b/ts/pageedit_zh_CN.ts
@@ -1,0 +1,1632 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
+<context>
+    <name>AppearanceWidget</name>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="14"/>
+        <source>Appearance</source>
+        <translation>外观</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="25"/>
+        <source>PageEdit</source>
+        <translation>PageEdit</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="31"/>
+        <location filename="../PAppearanceWidget.ui" line="263"/>
+        <source>Fonts:</source>
+        <translation>字体：</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="40"/>
+        <source>If no font is specified in the CSS for your page, the following font will be used to display within PageEdit. These fonts will not be used in your actual ebook.</source>
+        <translation>如果您页面的 CSS 中没有指定字体，则 PageEdit 显示时会使用以下的字体。这些字体不会真的用在您的电子书中。</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="70"/>
+        <source>Default font size to be used for PageEdit
+if no font-size specified in your CSS</source>
+        <translation>若是您的 CSS 档中未指定字体大小时，
+用于 PageEdit 的预设字体大小</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="74"/>
+        <location filename="../PAppearanceWidget.ui" line="323"/>
+        <source>Font Size:</source>
+        <translation>字体大小:</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="81"/>
+        <source>Default font family to be used for PageEdit
+if no font-family specified in your CSS</source>
+        <translation>若是您的 CSS 中没有指定字体族时，
+用于 PageEdit 的预设字体族</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="85"/>
+        <source>Standard:</source>
+        <translation>标准：</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="108"/>
+        <source>Default font family to be used for PageEdit
+if a serif font-family specified in your CSS</source>
+        <translation>若是您的 CSS 档中指定了Serif字体族时，
+用于 PageEdit 的预设字体族</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="112"/>
+        <source>Serif:</source>
+        <translation>Serif字体：</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="125"/>
+        <source>Default font family to be used for PageEdit
+if a sans-serif font-family specified in your CSS</source>
+        <translation>若是您的 CSS 档中指定了sans-serif字体族时，
+用于 PageEdit 的预设字体族</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="129"/>
+        <source>Sans-Serif:</source>
+        <translation>Sans-Serif字体：</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="156"/>
+        <source>Make PageEdit simulate a dark appearance in dark mode</source>
+        <translation>在暗色模式使 PageEdit 模拟暗色外观</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="181"/>
+        <source>Main UI</source>
+        <translation>主界面</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="187"/>
+        <source>Main Menu Icon Size:</source>
+        <translation>主菜单图标大小：</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="193"/>
+        <source>Adjust the size of the icons in the main menu.</source>
+        <translation>调整主菜单里的图标大小。</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="231"/>
+        <source>High DPI Setting:</source>
+        <translation>High DPI 设置：</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="240"/>
+        <source>(Needs PageEdit Restart)</source>
+        <translation>（PageEdit 需要重新启动）</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="269"/>
+        <source>UI Font:</source>
+        <translation>UI字体：</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="279"/>
+        <source>Change the font used by PageEdit&apos;s menus, buttons, etc...</source>
+        <translation>改变 PageEdit 的菜单、按钮等使用的字体</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="282"/>
+        <source>Change Font (Needs PageEdit Restart)</source>
+        <translation>改变字体（PageEdit 需要重新启动）</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="306"/>
+        <source>Insert Special Characters:</source>
+        <translation>插入特殊字符：</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="320"/>
+        <source>Font size to be used for Insert Special Characters window</source>
+        <translation>字体大小用于插入特殊字符的窗口</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="353"/>
+        <source>Font family to be used for Insert Special Characters window</source>
+        <translation>字体族用于插入特殊字符的窗口</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="356"/>
+        <source>Standard Font:</source>
+        <translation>标准字体：</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="423"/>
+        <source>Reset all fonts and colors to the default values</source>
+        <translation>将所有字体与颜色恢复预设值</translation>
+    </message>
+    <message>
+        <location filename="../PAppearanceWidget.ui" line="426"/>
+        <source>Reset All</source>
+        <translation>全部重设</translation>
+    </message>
+    <message>
+        <location filename="../AppearanceWidget.cpp" line="49"/>
+        <location filename="../AppearanceWidget.cpp" line="50"/>
+        <source>Detect</source>
+        <translation>检测</translation>
+    </message>
+    <message>
+        <location filename="../AppearanceWidget.cpp" line="49"/>
+        <location filename="../AppearanceWidget.cpp" line="52"/>
+        <source>On</source>
+        <translation>开</translation>
+    </message>
+    <message>
+        <location filename="../AppearanceWidget.cpp" line="49"/>
+        <location filename="../AppearanceWidget.cpp" line="54"/>
+        <source>Off</source>
+        <translation>关</translation>
+    </message>
+    <message>
+        <location filename="../AppearanceWidget.cpp" line="50"/>
+        <source>Detect whether any high dpi scaling should take place.</source>
+        <translation>检测是否进行 High DPI 缩放。</translation>
+    </message>
+    <message>
+        <location filename="../AppearanceWidget.cpp" line="51"/>
+        <source>Defers to any Qt environment variables that are set to control high dpi behavior.</source>
+        <translation>服从所有设置控制 High DPI 行为的 Qt 环境变量。</translation>
+    </message>
+    <message>
+        <location filename="../AppearanceWidget.cpp" line="52"/>
+        <source>Turns on high dpi scaling and ignores any Qt environment variables</source>
+        <translation>开启 High DPI 缩放并忽略任何 Qt 环境变量</translation>
+    </message>
+    <message>
+        <location filename="../AppearanceWidget.cpp" line="53"/>
+        <source>that are set controlling high dpi behavior.</source>
+        <translation>设置 High DPI 行为的 Qt 环境变量。</translation>
+    </message>
+    <message>
+        <location filename="../AppearanceWidget.cpp" line="54"/>
+        <source>Turns off high dpi scaling regardless if any Qt environment</source>
+        <translation>关闭 High DPI 缩放，忽略所有 Qt 环境变量</translation>
+    </message>
+    <message>
+        <location filename="../AppearanceWidget.cpp" line="55"/>
+        <source>variables controlling high dpi behavior are set.</source>
+        <translation>设置 High DPI 行为的 Qt 环境变量。</translation>
+    </message>
+</context>
+<context>
+    <name>GeneralSettings</name>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="14"/>
+        <source>General Settings</source>
+        <translation>通用设置</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="37"/>
+        <source>You must restart PageEdit after changing the User Interface language.
+
+If a translation for specific word or phrase is not available it will be displayed in English.</source>
+        <translation>改变用户界面的语言后，您必须重新启动 PageEdit。
+
+若某些特定字词或词组的翻译不有，则会以英文显示。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="42"/>
+        <source>User Interface Language:</source>
+        <translation>用户界面语言：</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="74"/>
+        <source>Select from installed spellcheck dictionaries.</source>
+        <translation>从已安装的拼写检查字典中选择。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="77"/>
+        <source>Spellcheck Dictionary:</source>
+        <translation>拼写检查字典：</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="119"/>
+        <source>Determine if html files are allowed to access non-multimedia remote resources.</source>
+        <translation>决定是否允许 html 文档访问远程非多媒体资源。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="122"/>
+        <source> Control access by html files to non-multimedia remote resources.</source>
+        <translation>html 文档远程访问非多媒体资源的访问控制。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="131"/>
+        <source>Check to allow html files to access non-multimedia remote resources.</source>
+        <translation>勾选是否允许 html 文档访问远程非多媒体资源。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="134"/>
+        <source>Html files may access all remote resources types.</source>
+        <translation>HTML 文档可以访问远程资源的类型。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="161"/>
+        <source>Determine if javascript is allowed to be used by html files</source>
+        <translation>决定是否允许 html 文档使用 javascript 脚本</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="164"/>
+        <source> Control use of javascript by html files.</source>
+        <translation>html 文档使用 javascript 脚本的控制。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="173"/>
+        <source>Check to allow html files to use javascript.</source>
+        <translation>勾选是否允许 html 文档使用 javascript 脚本。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="176"/>
+        <source>Html files may use javascript.</source>
+        <translation>html 文档可以使用 javascript。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="204"/>
+        <source>Choose how you would like PageEdit to handle the use of multiple white space characters during editing.</source>
+        <translation>选择您希望 PageEdit 在编辑时如何处理多个空白字符。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="207"/>
+        <source>Handle multiple white space layout using:</source>
+        <translation>处理多个空格布局配置使用：</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="213"/>
+        <source>Use CSS white-space: pre-wrap</source>
+        <translation>使用 CSS 空白字符：pre-wrap</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="216"/>
+        <source>css white-space: pre-wrap</source>
+        <translation>CSS 空白字符：pre-wrap</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="226"/>
+        <source>Use non-breaking spaces as needed</source>
+        <translation>根据需要使用不换行空格</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="229"/>
+        <source>non-breaking spaces as needed</source>
+        <translation>根据需要使用不换行空格</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="257"/>
+        <source>Determine if Prettify is used when saving</source>
+        <translation>决定保存时是否要使用美化</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="260"/>
+        <source> Use Prettify to reformat the xhtml when saving.</source>
+        <translation>保存时使用美化来重新格式化 xhtml。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="269"/>
+        <source>Check to reformat with Prettify when saving xhtml files.</source>
+        <translation>勾选以在保存 xhtml 文档时使用美化来重新格式化。</translation>
+    </message>
+    <message>
+        <location filename="../PGeneralSettings.ui" line="272"/>
+        <source>Use Prettify to reformat xhtml when saving.</source>
+        <translation>保存时使用美化来重新格式化 xhtml。</translation>
+    </message>
+</context>
+<context>
+    <name>Inspector</name>
+    <message>
+        <location filename="../Inspector.cpp" line="74"/>
+        <source>Inspect Page or Element</source>
+        <translation>检查页面或元素</translation>
+    </message>
+    <message>
+        <location filename="../Inspector.cpp" line="156"/>
+        <source>The Inspector functionality is not supported before Qt 5.11</source>
+        <translation>Qt 5.11 之前不支持检查器功能</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../main.ui" line="15"/>
+        <location filename="../MainWindow.cpp" line="929"/>
+        <location filename="../MainWindow.cpp" line="988"/>
+        <location filename="../MainWindow.cpp" line="1616"/>
+        <location filename="../MainWindow.cpp" line="1629"/>
+        <location filename="../MainWindow.cpp" line="1635"/>
+        <location filename="../MainWindow.cpp" line="1649"/>
+        <location filename="../MainWindow.cpp" line="1662"/>
+        <location filename="../MainWindow.cpp" line="1670"/>
+        <location filename="../MainWindow.cpp" line="1724"/>
+        <location filename="../MainWindow.cpp" line="1807"/>
+        <location filename="../MainWindow.cpp.keep" line="929"/>
+        <location filename="../MainWindow.cpp.keep" line="988"/>
+        <location filename="../MainWindow.cpp.keep" line="1616"/>
+        <location filename="../MainWindow.cpp.keep" line="1629"/>
+        <location filename="../MainWindow.cpp.keep" line="1635"/>
+        <location filename="../MainWindow.cpp.keep" line="1649"/>
+        <location filename="../MainWindow.cpp.keep" line="1662"/>
+        <location filename="../MainWindow.cpp.keep" line="1670"/>
+        <location filename="../MainWindow.cpp.keep" line="1724"/>
+        <location filename="../MainWindow.cpp.keep" line="1807"/>
+        <location filename="../MainWindow.cpp~" line="929"/>
+        <location filename="../MainWindow.cpp~" line="988"/>
+        <location filename="../MainWindow.cpp~" line="1616"/>
+        <location filename="../MainWindow.cpp~" line="1629"/>
+        <location filename="../MainWindow.cpp~" line="1635"/>
+        <location filename="../MainWindow.cpp~" line="1649"/>
+        <location filename="../MainWindow.cpp~" line="1662"/>
+        <location filename="../MainWindow.cpp~" line="1670"/>
+        <location filename="../MainWindow.cpp~" line="1724"/>
+        <location filename="../MainWindow.cpp~" line="1807"/>
+        <source>PageEdit</source>
+        <translation>PageEdit</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="62"/>
+        <source>&amp;File</source>
+        <translation>文档(&amp;F)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="74"/>
+        <source>&amp;Edit</source>
+        <translation>编辑(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="87"/>
+        <source>&amp;Find</source>
+        <translation>查找(&amp;F)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="94"/>
+        <source>&amp;Insert</source>
+        <translation>插入(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="109"/>
+        <source>For&amp;mat</source>
+        <translation>格式(&amp;M)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="114"/>
+        <source>&amp;Heading</source>
+        <translation>标题(&amp;H)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="147"/>
+        <source>&amp;View</source>
+        <translation>视图(&amp;V)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="156"/>
+        <source>Inspector</source>
+        <translation>检查器</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="172"/>
+        <source>File</source>
+        <translation>文档</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="186"/>
+        <source>Edit</source>
+        <translation>编辑</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="204"/>
+        <location filename="../main.ui" line="1055"/>
+        <source>Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="217"/>
+        <source>Insert</source>
+        <translation>插入</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="236"/>
+        <source>Inspect</source>
+        <translation>检查</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="249"/>
+        <location filename="../main.ui" line="1004"/>
+        <source>Find</source>
+        <translation>查找</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="262"/>
+        <source>Heading</source>
+        <translation>标题</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="276"/>
+        <source>set Heading Level of Selected Text</source>
+        <translation>设置所选取文字的标题等级</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="290"/>
+        <source>Format</source>
+        <translation>格式</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="308"/>
+        <source>Align</source>
+        <translation>对齐</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="324"/>
+        <source>Indent</source>
+        <translation>缩进</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="338"/>
+        <source>Navigate</source>
+        <translation>导航</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="348"/>
+        <source>Navigation List</source>
+        <translation>导航清单</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="364"/>
+        <source>&amp;Save</source>
+        <translation>保存(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="367"/>
+        <source>Save the current file.</source>
+        <translation>保存当前文档。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="370"/>
+        <source>Ctrl+S</source>
+        <translation>Ctrl+S</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="376"/>
+        <source>Save &amp;As...</source>
+        <translation>另存为(&amp;A)...</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="379"/>
+        <source>Save the current file with a different filename.</source>
+        <translation>以不同的文件名保存当前文档。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="382"/>
+        <source>Ctrl+Shift+S</source>
+        <translation>Ctrl+Shift+S</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="392"/>
+        <source>Cu&amp;t</source>
+        <translation>剪切(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="395"/>
+        <source>Cuts the selected text from the document and puts it on the clipboard.</source>
+        <translation>将选取的文字从文件中剪切，并放入粘贴簿。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="405"/>
+        <source>&amp;Paste</source>
+        <translation>粘贴(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="408"/>
+        <source>Pastes the content from the clipboard into the file.</source>
+        <translation>将粘贴簿的内容粘贴到文档中。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="418"/>
+        <source>&amp;Undo</source>
+        <translation>撤回(&amp;A)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="421"/>
+        <source>Reverts the changes of the previous operation.</source>
+        <translation>恢复上一个操作的改变。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="424"/>
+        <source>Ctrl+Z</source>
+        <translation>Ctrl+Z</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="434"/>
+        <source>&amp;Redo</source>
+        <translation>重做(&amp;R)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="437"/>
+        <source>Restores the changes reverted by the previous Undo action.</source>
+        <translation>恢复上一个撤回动作的改变。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="440"/>
+        <source>Ctrl+Y</source>
+        <translation>Ctrl+Y</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="450"/>
+        <source>&amp;Copy</source>
+        <translation>复制(&amp;C)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="453"/>
+        <source>Copies the selected text and puts it on the clipboard.</source>
+        <translation>复制选取的文字，并放入粘贴簿。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="466"/>
+        <source>Align &amp;Left</source>
+        <translation>左对齐(&amp;L)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="469"/>
+        <source>Align the paragraph to the left.</source>
+        <translation>将段落左对齐。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="483"/>
+        <source>Align &amp;Right</source>
+        <translation>右对齐(&amp;R)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="486"/>
+        <source>Align the paragraph to the right.</source>
+        <translation>将段落右对齐。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="499"/>
+        <source>&amp;Center</source>
+        <translation>置中(&amp;C)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="502"/>
+        <source>Center the paragraph.</source>
+        <translation>将段落置中。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="505"/>
+        <source>Ctrl+E</source>
+        <translation>Ctrl+E</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="518"/>
+        <source>&amp;Justify</source>
+        <translation>左右对齐(&amp;J)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="521"/>
+        <source>Align the paragraph to both the left and right margins.</source>
+        <translation>将段落左右两边对齐。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="524"/>
+        <source>Ctrl+J</source>
+        <translation>Ctrl+J</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="537"/>
+        <source>&amp;Bold</source>
+        <translation>粗体(&amp;B)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="540"/>
+        <source>Make the selected text bold.</source>
+        <translation>将选取的文字设为粗体字。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="543"/>
+        <source>Ctrl+B</source>
+        <translation>Ctrl+B</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="556"/>
+        <source>&amp;Italic</source>
+        <translation>斜体(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="559"/>
+        <source>Make the selected text italic.</source>
+        <translation>将选取的文字设为斜体字。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="562"/>
+        <source>Ctrl+I</source>
+        <translation>Ctrl+I</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="572"/>
+        <source>&amp;Open...</source>
+        <translation>打开(&amp;O)...</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="575"/>
+        <source>Open a file from disk.</source>
+        <translation>从磁盘打开文档。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="578"/>
+        <source>Ctrl+O</source>
+        <translation>Ctrl+O</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="592"/>
+        <source>&amp;Underline</source>
+        <translation>下划线(&amp;U)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="595"/>
+        <source>Underline the selected text.</source>
+        <translation>将选取的文字加下划线。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="598"/>
+        <source>Ctrl+U</source>
+        <translation>Ctrl+U</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="608"/>
+        <source>&amp;Quit</source>
+        <translation>退出(&amp;Q)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="611"/>
+        <source>Quit</source>
+        <translation>退出</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="614"/>
+        <source>Ctrl+Q</source>
+        <translation>Ctrl+Q</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="624"/>
+        <source>&amp;Special Character...</source>
+        <translation>特殊字符(&amp;S)...</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="627"/>
+        <source>Select a character to insert into your text.</source>
+        <translation>选择要插入文本的字符。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="640"/>
+        <source>&amp;Numbered List</source>
+        <translation>编号列表(&amp;N)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="643"/>
+        <source>Create a numbered list from selection.</source>
+        <translation>从选取的内容建立编号列表。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="656"/>
+        <source>Bulle&amp;ted List</source>
+        <translation>项目符号列表(&amp;T)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="659"/>
+        <source>Create a bulleted list from selection.</source>
+        <translation>从选取的内容建立项目符号列表。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="662"/>
+        <source>Ctrl+Shift+L</source>
+        <translation>Ctrl+Shift+L</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="675"/>
+        <source>Stri&amp;kethrough</source>
+        <translation>删除线(&amp;K)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="678"/>
+        <source>Draw a line through the selected text.</source>
+        <translation>将选取的文字加删除线。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="691"/>
+        <source>&amp;Subscript</source>
+        <translation>下标(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="694"/>
+        <source>Set the selected text slightly smaller and below the normal line.</source>
+        <translation>将选取的文字设为下标。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="707"/>
+        <source>Su&amp;perscript</source>
+        <translation>上标(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="710"/>
+        <source>Set the selected text slightly smaller and above the normal line.</source>
+        <translation>将选取的文字设为上标。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="721"/>
+        <source>Zoom &amp;In</source>
+        <translation>放大(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="724"/>
+        <source>Zoom In</source>
+        <translation>放大</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="727"/>
+        <source>Ctrl+=</source>
+        <translation>Ctrl+=</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="738"/>
+        <source>Zoom &amp;Out</source>
+        <translation>缩小(&amp;O)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="741"/>
+        <source>Zoom Out</source>
+        <translation>缩小</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="744"/>
+        <source>Ctrl+-</source>
+        <translation>Ctrl+-</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="755"/>
+        <source>Incre&amp;ase Indent</source>
+        <translation>增加缩进(&amp;A)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="758"/>
+        <source>Increase the indent level of the paragraph.</source>
+        <translation>增加段落的缩进等级。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="761"/>
+        <source>Ctrl+Alt+M</source>
+        <translation>Ctrl+Alt+M</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="771"/>
+        <source>&amp;Decrease Indent</source>
+        <translation>减少缩进(&amp;D)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="774"/>
+        <source>Decrease the indent level of the paragraph.</source>
+        <translation>减少段落的缩进等级。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="777"/>
+        <source>Ctrl+Shift+M</source>
+        <translation>Ctrl+Shift+M</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="787"/>
+        <source>Split &amp;Marker</source>
+        <translation>分割标记(&amp;M)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="790"/>
+        <source>Insert Sigil split file marker</source>
+        <translation>插入 Sigil 分割文档标记</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="793"/>
+        <source>Ctrl+Shift+Return</source>
+        <translation>Ctrl+Shift+Return</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="799"/>
+        <source>&amp;Preferences...</source>
+        <translation>偏好设置(&amp;P)...</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="802"/>
+        <source>F5</source>
+        <translation>F5</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="808"/>
+        <source>&amp;Zoom Reset</source>
+        <translation>重设缩放(&amp;Z)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="811"/>
+        <source>Zoom Reset</source>
+        <translation>重设缩放</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="814"/>
+        <source>Ctrl+0</source>
+        <translation>Ctrl+0</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="827"/>
+        <source>Heading &amp;1</source>
+        <translation>标题 &amp;1</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="830"/>
+        <source>Format paragraph as a level 1 heading.</source>
+        <translation>将段落设为第一级标题。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="833"/>
+        <source>Ctrl+1</source>
+        <translation>Ctrl+1</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="846"/>
+        <source>Heading &amp;2</source>
+        <translation>标题 &amp;2</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="849"/>
+        <source>Format paragraph as a level 2 heading.</source>
+        <translation>将段落设为第二级标题。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="852"/>
+        <source>Ctrl+2</source>
+        <translation>Ctrl+2</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="865"/>
+        <source>Heading &amp;3</source>
+        <translation>标题 &amp;3</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="868"/>
+        <source>Format paragraph as a level 3 heading.</source>
+        <translation>将段落设为第三级标题。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="871"/>
+        <source>Ctrl+3</source>
+        <translation>Ctrl+3</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="885"/>
+        <source>Heading &amp;4</source>
+        <translation>标题 &amp;4</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="888"/>
+        <source>Format paragraph as a level 4 heading.</source>
+        <translation>将段落设为第四级标题。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="891"/>
+        <source>Ctrl+4</source>
+        <translation>Ctrl+4</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="904"/>
+        <source>Heading &amp;5</source>
+        <translation>标题 &amp;5</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="907"/>
+        <source>Format paragraph as a level 5 heading.</source>
+        <translation>将段落设为第五级标题。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="910"/>
+        <source>Ctrl+5</source>
+        <translation>Ctrl+5</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="923"/>
+        <source>Heading &amp;6</source>
+        <translation>标题 &amp;6</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="926"/>
+        <source>Format paragraph as a level 6 heading.</source>
+        <translation>将段落设为第六级标题。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="929"/>
+        <source>Ctrl+6</source>
+        <translation>Ctrl+6</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="943"/>
+        <source>&amp;Normal</source>
+        <translation>一般(&amp;N)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="946"/>
+        <source>ormat paragraph as a normal paragraph.</source>
+        <translation>将段落格式化为一般的段落。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="949"/>
+        <source>Ctrl+7</source>
+        <translation>Ctrl+7</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="959"/>
+        <source>&amp;Preserve Existing Attributes</source>
+        <translation>预留现有的属性(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="962"/>
+        <source>When applying this style, preserve any existing attributes on the tag</source>
+        <translation>套用此样式表时，保留标签里现有的所有属性</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="972"/>
+        <source>&amp;Select All</source>
+        <translation>全部选取(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="975"/>
+        <source>Select all text in the document.</source>
+        <translation>选取文件中所有文字。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="978"/>
+        <source>Ctrl+A</source>
+        <translation>Ctrl+A</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="988"/>
+        <source>&amp;Inspector</source>
+        <translation>检查器(&amp;I)</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="991"/>
+        <source>Inspect the page.</source>
+        <translation>检查页面。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="994"/>
+        <source>Ctrl+F5</source>
+        <translation>Ctrl+F5</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1007"/>
+        <source>Find text in the page</source>
+        <translation>在页面中查找文字</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1010"/>
+        <source>Ctrl+F</source>
+        <translation>Ctrl+F</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1023"/>
+        <source>Next XHtml File</source>
+        <translation>下一个 XHtml 文档</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1026"/>
+        <source>Next file in navigation list</source>
+        <translation>导航清单中的下一个文档</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1039"/>
+        <source>Previous XHtml File</source>
+        <translation>上一个 XHtml 文档</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1042"/>
+        <source>Previous file in navigation list</source>
+        <translation>导航清单中的上一个文档</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1058"/>
+        <source>Toggle between Edit and Preview Modes.</source>
+        <translation>在编辑和预览模式间切换。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1068"/>
+        <source>About...</source>
+        <translation>关于...</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1071"/>
+        <source>Show information about PageEdit.</source>
+        <translation>显示关于 PageEdit 的信息。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1081"/>
+        <source>Back to Last Link</source>
+        <translation>回到上一个链接</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1084"/>
+        <source>Return from the last link taken</source>
+        <translation>从上一个链接返回</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1094"/>
+        <source>I&amp;D...</source>
+        <translation>ID(&amp;)...</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1097"/>
+        <source>Insert or edit an anchor with an ID name to use as a link target.</source>
+        <translation>插入或编辑具有 ID 名称的锚点，以作为链接目标。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1107"/>
+        <source>&amp;Link...</source>
+        <translation>链接(&amp;L)...</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1110"/>
+        <source>Insert or edit an anchor with a hyperlink to a target.</source>
+        <translation>插入或编辑超链接到目标的锚点。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1120"/>
+        <source>&amp;File...</source>
+        <translation>文档(&amp;F)...</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1123"/>
+        <source>Select existing image, video or audio files from your book to insert into the text.</source>
+        <translation>从书籍中选择已有的图片、视频或音频文档，并插入到文本中。</translation>
+    </message>
+    <message>
+        <location filename="../main.ui" line="1126"/>
+        <source>Ctrl+Shift+I</source>
+        <translation>Ctrl+Shift+I</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="667"/>
+        <location filename="../MainWindow.cpp.keep" line="667"/>
+        <location filename="../MainWindow.cpp~" line="667"/>
+        <source>File load failed</source>
+        <translation>文档载入失败</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="668"/>
+        <location filename="../MainWindow.cpp.keep" line="668"/>
+        <location filename="../MainWindow.cpp~" line="668"/>
+        <source>File Load Failed</source>
+        <translation>文档载入失败</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="763"/>
+        <location filename="../MainWindow.cpp.keep" line="763"/>
+        <location filename="../MainWindow.cpp~" line="763"/>
+        <source>mode: Preview</source>
+        <translation>模式：预览</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="765"/>
+        <location filename="../MainWindow.cpp.keep" line="765"/>
+        <location filename="../MainWindow.cpp~" line="765"/>
+        <source>mode: Edit</source>
+        <translation>模式：编辑</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="929"/>
+        <location filename="../MainWindow.cpp.keep" line="929"/>
+        <location filename="../MainWindow.cpp~" line="929"/>
+        <source>Are you sure you want to open this link in your browser?
+
+%1</source>
+        <translation>您确定要在浏览器打开这个链接吗？
+
+%1</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="989"/>
+        <location filename="../MainWindow.cpp.keep" line="989"/>
+        <location filename="../MainWindow.cpp~" line="989"/>
+        <source>Do you want to save your changes before leaving?</source>
+        <translation>您要在退出前保存改变吗？</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1006"/>
+        <location filename="../MainWindow.cpp.keep" line="1006"/>
+        <location filename="../MainWindow.cpp~" line="1006"/>
+        <source>PageEdit is closing...</source>
+        <translation>PageEdit 正在关闭...</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1134"/>
+        <location filename="../MainWindow.cpp" line="1135"/>
+        <location filename="../MainWindow.cpp" line="1136"/>
+        <location filename="../MainWindow.cpp" line="1145"/>
+        <location filename="../MainWindow.cpp" line="1146"/>
+        <location filename="../MainWindow.cpp" line="1147"/>
+        <location filename="../MainWindow.cpp.keep" line="1134"/>
+        <location filename="../MainWindow.cpp.keep" line="1135"/>
+        <location filename="../MainWindow.cpp.keep" line="1136"/>
+        <location filename="../MainWindow.cpp.keep" line="1145"/>
+        <location filename="../MainWindow.cpp.keep" line="1146"/>
+        <location filename="../MainWindow.cpp.keep" line="1147"/>
+        <location filename="../MainWindow.cpp~" line="1134"/>
+        <location filename="../MainWindow.cpp~" line="1135"/>
+        <location filename="../MainWindow.cpp~" line="1136"/>
+        <location filename="../MainWindow.cpp~" line="1145"/>
+        <location filename="../MainWindow.cpp~" line="1146"/>
+        <location filename="../MainWindow.cpp~" line="1147"/>
+        <source>HTML files (*.htm *.html *.xhtml)</source>
+        <translation>HTML文档 (*.htm *.html *.xhtml)</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1137"/>
+        <location filename="../MainWindow.cpp.keep" line="1137"/>
+        <location filename="../MainWindow.cpp~" line="1137"/>
+        <source>OPF files (*.opf)</source>
+        <translation>OPF 文档 (*.opf)</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1138"/>
+        <location filename="../MainWindow.cpp.keep" line="1138"/>
+        <location filename="../MainWindow.cpp~" line="1138"/>
+        <source>All files (*.*)</source>
+        <translation>所有文档(*.*)</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1376"/>
+        <location filename="../MainWindow.cpp.keep" line="1376"/>
+        <location filename="../MainWindow.cpp~" line="1376"/>
+        <source>Save File</source>
+        <translation>保存文档</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1411"/>
+        <location filename="../MainWindow.cpp" line="1412"/>
+        <location filename="../MainWindow.cpp" line="1424"/>
+        <location filename="../MainWindow.cpp" line="1425"/>
+        <location filename="../MainWindow.cpp.keep" line="1411"/>
+        <location filename="../MainWindow.cpp.keep" line="1412"/>
+        <location filename="../MainWindow.cpp.keep" line="1424"/>
+        <location filename="../MainWindow.cpp.keep" line="1425"/>
+        <location filename="../MainWindow.cpp~" line="1411"/>
+        <location filename="../MainWindow.cpp~" line="1412"/>
+        <location filename="../MainWindow.cpp~" line="1424"/>
+        <location filename="../MainWindow.cpp~" line="1425"/>
+        <source>File Save-As Failed!</source>
+        <translation>另存为新文档失败！</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1411"/>
+        <location filename="../MainWindow.cpp.keep" line="1411"/>
+        <location filename="../MainWindow.cpp~" line="1411"/>
+        <source>is not writeable</source>
+        <translation>无法写入</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1420"/>
+        <location filename="../MainWindow.cpp" line="1459"/>
+        <location filename="../MainWindow.cpp.keep" line="1420"/>
+        <location filename="../MainWindow.cpp.keep" line="1459"/>
+        <location filename="../MainWindow.cpp~" line="1420"/>
+        <location filename="../MainWindow.cpp~" line="1459"/>
+        <source>File Saved</source>
+        <translation>文档已保存</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1450"/>
+        <location filename="../MainWindow.cpp" line="1452"/>
+        <location filename="../MainWindow.cpp" line="1463"/>
+        <location filename="../MainWindow.cpp" line="1464"/>
+        <location filename="../MainWindow.cpp.keep" line="1450"/>
+        <location filename="../MainWindow.cpp.keep" line="1452"/>
+        <location filename="../MainWindow.cpp.keep" line="1463"/>
+        <location filename="../MainWindow.cpp.keep" line="1464"/>
+        <location filename="../MainWindow.cpp~" line="1450"/>
+        <location filename="../MainWindow.cpp~" line="1452"/>
+        <location filename="../MainWindow.cpp~" line="1463"/>
+        <location filename="../MainWindow.cpp~" line="1464"/>
+        <source>File Save Failed!</source>
+        <translation>文档保存失败！</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1451"/>
+        <location filename="../MainWindow.cpp.keep" line="1451"/>
+        <location filename="../MainWindow.cpp~" line="1451"/>
+        <source>does not exist or is not writeable</source>
+        <translation>不存在或无法写入</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1512"/>
+        <location filename="../MainWindow.cpp.keep" line="1512"/>
+        <location filename="../MainWindow.cpp~" line="1512"/>
+        <source>File Opened</source>
+        <translation>文档已打开</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1516"/>
+        <location filename="../MainWindow.cpp.keep" line="1516"/>
+        <location filename="../MainWindow.cpp~" line="1516"/>
+        <source>File Open Failed!</source>
+        <translation>文档打开失败！</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1539"/>
+        <location filename="../MainWindow.cpp.keep" line="1539"/>
+        <location filename="../MainWindow.cpp~" line="1539"/>
+        <source>Clipboard contains HTML formatting</source>
+        <translation>粘贴簿包含 HTML 格式</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1540"/>
+        <location filename="../MainWindow.cpp.keep" line="1540"/>
+        <location filename="../MainWindow.cpp~" line="1540"/>
+        <source>Do you want to paste clipboard data as plain text?</source>
+        <translation>你要以纯文本方式粘贴数据吗？</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1616"/>
+        <location filename="../MainWindow.cpp.keep" line="1616"/>
+        <location filename="../MainWindow.cpp~" line="1616"/>
+        <source>You must select text before inserting a new id.</source>
+        <translation>在插入新的代码前您必须选取文字。</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1629"/>
+        <location filename="../MainWindow.cpp.keep" line="1629"/>
+        <location filename="../MainWindow.cpp~" line="1629"/>
+        <source>ID is invalid - must start with a letter, followed by letter number _ : - or .</source>
+        <translation>ID 不合法 - 需要以字母开头，后面跟着字母、数字、_ : - 或 .</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1635"/>
+        <location filename="../MainWindow.cpp.keep" line="1635"/>
+        <location filename="../MainWindow.cpp~" line="1635"/>
+        <source>You cannot insert an id at this position.</source>
+        <translation>您不能在此位置插入 ID。</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1649"/>
+        <location filename="../MainWindow.cpp.keep" line="1649"/>
+        <location filename="../MainWindow.cpp~" line="1649"/>
+        <source>You must select text before inserting a new link.</source>
+        <translation>在插入新的链接前您必须选取文字。</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1662"/>
+        <location filename="../MainWindow.cpp.keep" line="1662"/>
+        <location filename="../MainWindow.cpp~" line="1662"/>
+        <source>Link is invalid - cannot contain &apos;&lt;&apos; or &apos;&gt;&apos;</source>
+        <translation>链接不合法 - 不能含有 &apos;&lt;&apos; 或 &apos;&gt;&apos;</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1670"/>
+        <location filename="../MainWindow.cpp.keep" line="1670"/>
+        <location filename="../MainWindow.cpp~" line="1670"/>
+        <source>You cannot insert a link at this position.</source>
+        <translation>您不能在此位置插入链接。</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1681"/>
+        <location filename="../MainWindow.cpp.keep" line="1681"/>
+        <location filename="../MainWindow.cpp~" line="1681"/>
+        <source>Insert File</source>
+        <translation>插入文档</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1724"/>
+        <location filename="../MainWindow.cpp.keep" line="1724"/>
+        <location filename="../MainWindow.cpp~" line="1724"/>
+        <source>You cannot insert a media file at this position.</source>
+        <translation>您不能在此位置插入媒体文档。</translation>
+    </message>
+    <message>
+        <location filename="../MainWindow.cpp" line="1808"/>
+        <location filename="../MainWindow.cpp.keep" line="1808"/>
+        <location filename="../MainWindow.cpp~" line="1808"/>
+        <source>Do you want to save any changes before overwriting this file?</source>
+        <translation>您要在覆写这个文档前保存改变吗？</translation>
+    </message>
+</context>
+<context>
+    <name>Preferences</name>
+    <message>
+        <location filename="../Preferences.ui" line="14"/>
+        <source>Preferences</source>
+        <translation>偏好设置</translation>
+    </message>
+    <message>
+        <location filename="../Preferences.cpp" line="90"/>
+        <source>PageEdit</source>
+        <translation>PageEdit</translation>
+    </message>
+    <message>
+        <location filename="../Preferences.cpp" line="90"/>
+        <source>Changes will take effect when you restart PageEdit.</source>
+        <translation>改变会在您重新启动 PageEdit 后生效。</translation>
+    </message>
+    <message>
+        <location filename="../Preferences.cpp" line="152"/>
+        <source>Open Preferences Location</source>
+        <translation>打开偏好设置的位置</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../OPFReader.cpp" line="58"/>
+        <source>Unable to read OPF file.
+Line: %1 Column %2 - %3</source>
+        <translation>无法读取 OPF 档。
+第 %1 行第 %2 栏 - %3</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="376"/>
+        <source>Cannot read file %1:
+%2.</source>
+        <translation>无法读取文档 %1:
+%2。</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="491"/>
+        <source>PageEdit has encountered a problem.</source>
+        <translation>PageEdit 遇到了问题。</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="492"/>
+        <source>PageEdit may need to close.</source>
+        <translation>PageEdit 可能需要关闭。</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="794"/>
+        <source>About PageEdit</source>
+        <translation>关于 PageEdit</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="799"/>
+        <source>Version</source>
+        <translation>版本</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="800"/>
+        <source>Build Date</source>
+        <translation>构建日期</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="801"/>
+        <source>Build Time</source>
+        <translation>构建时间</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="802"/>
+        <source>Qt Runtime Version</source>
+        <translation>Qt 运行时版本</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="803"/>
+        <source>Qt Compiled Version</source>
+        <translation>Qt 编译版本</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="804"/>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="805"/>
+        <source>Architecture</source>
+        <translation>架构</translation>
+    </message>
+</context>
+<context>
+    <name>SearchToolbar</name>
+    <message>
+        <location filename="../SearchToolbar.ui" line="36"/>
+        <source>Search: </source>
+        <translation>搜索：</translation>
+    </message>
+    <message>
+        <location filename="../SearchToolbar.ui" line="55"/>
+        <source>Search...</source>
+        <translation>搜索...</translation>
+    </message>
+    <message>
+        <location filename="../SearchToolbar.ui" line="88"/>
+        <source>&amp;Match Case</source>
+        <translation>匹配大小写敏感(&amp;M)</translation>
+    </message>
+    <message>
+        <location filename="../SearchToolbar.cpp" line="140"/>
+        <source>No results found.</source>
+        <translation>找不到结果。</translation>
+    </message>
+</context>
+<context>
+    <name>SelectCharacter</name>
+    <message>
+        <location filename="../SelectCharacter.ui" line="14"/>
+        <source>Insert Special Character</source>
+        <translation>插入特殊字符</translation>
+    </message>
+</context>
+<context>
+    <name>SelectFiles</name>
+    <message>
+        <location filename="../SelectFiles.ui" line="14"/>
+        <source>Insert File</source>
+        <translation>插入文档</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.ui" line="46"/>
+        <source>List only the file names which contain the text you enter.</source>
+        <translation>只列出包含您输入文字的文件名。</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.ui" line="49"/>
+        <source>Filter:</source>
+        <translation>过滤器:</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.ui" line="118"/>
+        <source>Thumbnail size:</source>
+        <translation>缩略图大小：</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.cpp" line="113"/>
+        <source>All</source>
+        <translation>全部</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.cpp" line="114"/>
+        <source>Images</source>
+        <translation>图片</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.cpp" line="115"/>
+        <source>Video</source>
+        <translation>视频</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.cpp" line="116"/>
+        <source>Audio</source>
+        <translation>音频</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.cpp" line="159"/>
+        <source>Media Files In the Book</source>
+        <translation>书中的媒体文档</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.cpp" line="162"/>
+        <source>Thumbnails</source>
+        <translation>缩略图</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.cpp" line="325"/>
+        <source>shades</source>
+        <translation>阴影</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.cpp" line="325"/>
+        <source>colors</source>
+        <translation>颜色</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.cpp" line="326"/>
+        <source>Grayscale</source>
+        <translation>灰阶</translation>
+    </message>
+    <message>
+        <location filename="../SelectFiles.cpp" line="326"/>
+        <source>Color</source>
+        <translation>颜色</translation>
+    </message>
+</context>
+<context>
+    <name>SelectHyperlink</name>
+    <message>
+        <location filename="../SelectHyperlink.ui" line="14"/>
+        <source>Select Target</source>
+        <translation>选择目标</translation>
+    </message>
+    <message>
+        <location filename="../SelectHyperlink.ui" line="22"/>
+        <source>List only the entries that match the text you enter.</source>
+        <translation>只列出匹配您输入文字的条目。</translation>
+    </message>
+    <message>
+        <location filename="../SelectHyperlink.ui" line="25"/>
+        <source>Filter:</source>
+        <translation>过滤器:</translation>
+    </message>
+    <message>
+        <location filename="../SelectHyperlink.ui" line="58"/>
+        <source>Enter the target URL for this hyperlink.  You can select or 
+double click on existing destinations in your book from the list above.</source>
+        <translation>则输入此超链接的目标网址。您可以在上方的清单中选择或双击在您的书本中已有的目标。</translation>
+    </message>
+    <message>
+        <location filename="../SelectHyperlink.ui" line="62"/>
+        <source>Target:</source>
+        <translation>目标:</translation>
+    </message>
+    <message>
+        <location filename="../SelectHyperlink.cpp" line="94"/>
+        <source>Targets in the Book</source>
+        <translation>书本中的目标</translation>
+    </message>
+    <message>
+        <location filename="../SelectHyperlink.cpp" line="95"/>
+        <source>Text</source>
+        <translation>文字</translation>
+    </message>
+</context>
+<context>
+    <name>SelectId</name>
+    <message>
+        <location filename="../SelectId.ui" line="14"/>
+        <source>Insert ID </source>
+        <translation>插入 ID </translation>
+    </message>
+    <message>
+        <location filename="../SelectId.ui" line="22"/>
+        <source>Enter an ID name to use as a destination for hyperlinks, notes, and TOC entries.
+
+The dropdown box shows existing ID names in the current file.
+
+ID names must be unique and start with a letter.</source>
+        <translation>输入超链接、备注与目录项目所使用的 ID 名称。
+
+此下拉框会显示当前文档中已有的 ID 名称。
+
+ID 名称不能重覆，并且必须以字母开头。</translation>
+    </message>
+    <message>
+        <location filename="../SelectId.ui" line="29"/>
+        <source>ID:</source>
+        <translation>ID:</translation>
+    </message>
+</context>
+<context>
+    <name>Utility</name>
+    <message>
+        <location filename="../Utility.cpp" line="587"/>
+        <source>PageEdit</source>
+        <translation>PageEdit</translation>
+    </message>
+    <message>
+        <location filename="../Utility.cpp" line="588"/>
+        <source>The requested file name contains non-ASCII characters. You should only use ASCII characters in filenames. Using non-ASCII characters can prevent the EPUB from working with some readers.
+
+Continue using the requested filename?</source>
+        <translation>请求的文件名包含了非 ASCII 字符。您的文件名中应该只使用 ASCII 字符。使用非 ASCII 字符可能会造成 EPUB 在某些阅读器中无法使用。
+
+您要继续使用该文件名吗？</translation>
+    </message>
+</context>
+<context>
+    <name>WebViewEdit</name>
+    <message>
+        <location filename="../WebViewEdit.cpp" line="167"/>
+        <source>No suggestions</source>
+        <translation>无建议</translation>
+    </message>
+    <message>
+        <location filename="../WebViewEdit.cpp" line="179"/>
+        <source>Check Spelling</source>
+        <translation>检查拼写</translation>
+    </message>
+    <message>
+        <location filename="../WebViewEdit.cpp" line="188"/>
+        <source>Select Language</source>
+        <translation>选择语言</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
1. I had finished to translate pageedit_en.ts into Simplified Chinese, and rename as pageedit_zh_CN.ts.
2. I used to Qt Linguist's lrelease tool compile  pageedit_zh_CN.ts to  pageedit_zh_CN.qm file, and copy it to pageedit's translations subdirectory.
3. When I run PageEdit application, it works fine, Simplified Chinese display all ok!