### PR TITLE
Quit PageEdit on macOS when the last editor window is closed

### DIFF
--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -1315,6 +1315,21 @@ void MainWindow::closeEvent(QCloseEvent *event)
     if (AllowSaveIfModified()) {
         SaveSettings();
         event->accept();
+
+#ifdef Q_OS_MAC
+        // macOS keeps a hidden basemw window alive (menubar workaround), so the app
+        // would otherwise stay running after the user clicks the red close button.
+        int other_editor_windows = 0;
+        foreach (QWidget *widget, QApplication::topLevelWidgets()) {
+            MainWindow *other = qobject_cast<MainWindow *>(widget);
+            if (other && other != this && other->isVisible()) {
+                other_editor_windows++;
+            }
+        }
+        if (other_editor_windows == 0) {
+            qApp->quit();
+        }
+#endif
         return;
     }
     event->ignore();

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -68,6 +68,10 @@
 #include "MainApplication.h"
 #include "MainWindow.h"
 
+#ifdef Q_OS_MAC
+extern QMainWindow *g_mac_menubar_window;
+#endif
+
 #define DBG if(0)
 
 static const QString SETTINGS_GROUP = "mainwindow";
@@ -1273,11 +1277,16 @@ void MainWindow::ReloadPreview()
 }
 
 // returns false if the user wants to cancel the exit
-bool MainWindow::AllowSaveIfModified() 
+bool MainWindow::AllowSaveIfModified(bool on_close)
 {
     // if the page source has been modified since it was loaded or saved
     // allow opportunity to save it
-    QString source = GetSource();
+    const int timeout_ms = on_close ? 3000 : 0;
+    const QString source = GetSource(timeout_ms);
+    if (on_close && source.isNull()) {
+        // WebEngine toHtml can stall while the window is closing on macOS
+        return true;
+    }
     // qDebug() << "new  source: " << source;
     // qDebug() << "orig source: " << m_source;
     bool modified = false;
@@ -1312,7 +1321,7 @@ bool MainWindow::AllowSaveIfModified()
 void MainWindow::closeEvent(QCloseEvent *event)
 {
     ShowMessageOnStatusBar(tr("PageEdit is closing..."));
-    if (AllowSaveIfModified()) {
+    if (AllowSaveIfModified(true)) {
         SaveSettings();
         event->accept();
 
@@ -1327,9 +1336,10 @@ void MainWindow::closeEvent(QCloseEvent *event)
             }
         }
         if (other_editor_windows == 0) {
-            // Defer quit so the close event can finish; calling quit() synchronously
-            // here can prevent the window from actually closing on macOS.
             QTimer::singleShot(0, qApp, []() {
+                if (g_mac_menubar_window) {
+                    g_mac_menubar_window->close();
+                }
                 qApp->quit();
             });
         }
@@ -1470,9 +1480,12 @@ void MainWindow::SetPreserveHeadingAttributes(bool new_state)
     ui.actionHeadingPreserveAttributes->setChecked(m_preserveHeadingAttributes);
 }
 
-QString MainWindow::GetSource() 
+QString MainWindow::GetSource(int timeout_ms)
 {
-    QString text = m_WebView->GetHtml();
+    QString text = m_WebView->GetHtml(timeout_ms);
+    if (text.isNull()) {
+        return QString();
+    }
     GumboInterface gi = GumboInterface(text, "any_version");
     QList<GumboNode*> nodes;
     // remove any added contenteditable attributes 

--- a/MainWindow.cpp
+++ b/MainWindow.cpp
@@ -1327,7 +1327,11 @@ void MainWindow::closeEvent(QCloseEvent *event)
             }
         }
         if (other_editor_windows == 0) {
-            qApp->quit();
+            // Defer quit so the close event can finish; calling quit() synchronously
+            // here can prevent the window from actually closing on macOS.
+            QTimer::singleShot(0, qApp, []() {
+                qApp->quit();
+            });
         }
 #endif
         return;

--- a/MainWindow.h
+++ b/MainWindow.h
@@ -218,7 +218,7 @@ protected:
     void closeEvent(QCloseEvent * event);
     bool MaybeSaveDialogSaysProceed(bool modified);
     QString GetCleanHtml();
-    QString GetSource();
+    QString GetSource(int timeout_ms = 0);
     QString GetHTMLToPaste(const QString & hmtl_snippet);
 
 private:
@@ -227,7 +227,7 @@ private:
     void SetupNavigationComboBox();
     void LoadSettings();
     void SaveSettings();
-    bool AllowSaveIfModified();
+    bool AllowSaveIfModified(bool on_close = false);
     void UpdateClipButton(QAction *ui_action);
     void ConnectSignalsToSlots();
 

--- a/WebViewEdit.cpp
+++ b/WebViewEdit.cpp
@@ -372,14 +372,28 @@ void WebViewEdit::UpdateFinishedState(bool okay)
     emit DocumentLoaded();
 }
 
-QString WebViewEdit::GetHtml() const 
+QString WebViewEdit::GetHtml(int timeout_ms) const
 {
-    HTMLResult * pres = new HTMLResult();
+    HTMLResult *pres = new HTMLResult();
     page()->toHtml(SetToHTMLResultFunctor(pres));
-    while(!pres->isFinished()) {
-        qApp->processEvents(QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers, 100);
+
+    if (timeout_ms <= 0) {
+        while (!pres->isFinished()) {
+            qApp->processEvents(QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers, 100);
+        }
+    } else {
+        int waited_ms = 0;
+        while (!pres->isFinished() && waited_ms < timeout_ms) {
+            qApp->processEvents(QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers, 50);
+            waited_ms += 50;
+        }
+        if (!pres->isFinished()) {
+            delete pres;
+            return QString();
+        }
     }
-    QString res = pres->res;
+
+    const QString res = pres->res;
     delete pres;
     return res;
 }

--- a/WebViewEdit.h
+++ b/WebViewEdit.h
@@ -124,10 +124,11 @@ public:
 
     bool SetAncestorTagAttributeValue(const QString &attribute_name, const QString &attribute_value, const QStringList &tag_list);
 
+    // timeout_ms <= 0 waits indefinitely; on timeout returns a null QString
+    QString GetHtml(int timeout_ms = 0) const;
 
 public slots:
      void PasteText(const QString &text);
-     QString GetHtml() const;
      QString GetSelectedText();
      void ApplyCaseChangeToSelection(const Utility::Casing &casing);
      bool InsertHtml(const QString &html);

--- a/main.cpp
+++ b/main.cpp
@@ -43,8 +43,10 @@
 # include <QFileDialog>
 # include <QKeySequence>
 # include <QAction>
+# include <QMainWindow>
 extern void disableWindowTabbing();
 extern void removeMacosSpecificMenuItems();
+QMainWindow *g_mac_menubar_window = nullptr;
 #endif
 
 #include "MainApplication.h"
@@ -432,6 +434,7 @@ int main(int argc, char *argv[])
 
     basemw->setMenuBar(mac_menu);
     basemw->show();
+    g_mac_menubar_window = basemw;
 #endif
 
     // Set ui font from preferences


### PR DESCRIPTION
## Summary

On macOS, PageEdit could remain running in the background after the user closed the last editor window with the red close button. Because the process stayed alive, launching PageEdit again from Sigil (External XHTML Editor, F2) for a different book often did nothing useful until PageEdit was quit manually from the Dock or Activity Monitor.

This change calls `qApp->quit()` when the last visible `MainWindow` is closed. It is limited to macOS, where `main.cpp` already uses `setQuitOnLastWindowClosed(false)` and a hidden `basemw` window as a menubar workaround for Qt bugs (QTBUG-62193 / QTBUG-65245). If more than one editor window is open, closing one window does not quit the application.

## Test plan

- [ ] On macOS, open a book in PageEdit from Sigil (F2), then close the editor with the red button; confirm PageEdit is no longer running in Activity Monitor
- [ ] From Sigil, open a second book with F2; confirm PageEdit launches normally without a manual quit in between
- [ ] Open two PageEdit editor windows, close one; confirm the other remains open and the app keeps running
- [ ] Confirm Ctrl+Q / File → Quit still exits the application


Made with [Cursor](https://cursor.com)