### PR TITLE
Corrected syntax in instructions for building from source on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ __Ubuntu__
 
 `mkdir build`<br>
 `cd build`<br>
-`cmake "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ../<path/to/PageEdit/source>`<br>
+`cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ../<path/to/PageEdit/source>`<br>
 `make`<br>
 
 __Arch Linux__
@@ -77,7 +77,7 @@ sudo pacman -S cmake qt6-webengine qt6-tools qt6-svg<br>
 
 `mkdir build`<br>
 `cd build`<br>
-`cmake "Unix Makefiles" -DINSTALL_BUNDLED_DICTS=0 -DCMAKE_BUILD_TYPE=Release ../<path/to/PageEdit/source>`<br>
+`cmake -G "Unix Makefiles" -DINSTALL_BUNDLED_DICTS=0 -DCMAKE_BUILD_TYPE=Release ../<path/to/PageEdit/source>`<br>
 `make`<br>
 
 __All Flavors__:


### PR DESCRIPTION
Thanks for making this software. I'm really excited to start using it on my new Linux e-ink tablet. I had to build from source, and I noticed a small but crucial typo or omission in the cmake commands in the README.md file. My changes make the text more consistent with the installation instructions in the Sigil-Ebook repo, but I don't know for certain if the changes I made really truly apply to Ubuntu or Arch because the machine I installed the software on uses Debian trixie.

If you feel that these changes are incorrect, feel free to decline them. Thanks again for making this! It's a very impressive app.